### PR TITLE
feat: add equality comparison for device command and state classes

### DIFF
--- a/src/libdeye/device_command.py
+++ b/src/libdeye/device_command.py
@@ -31,6 +31,22 @@ class DeyeDeviceCommand:
         self.mode = mode
         self.target_humidity = target_humidity
 
+    def __eq__(self, other: object) -> bool:
+        """Check if two DeyeDeviceCommand instances are equal."""
+        if not isinstance(other, DeyeDeviceCommand):
+            return False
+
+        return (
+            self.anion_switch == other.anion_switch
+            and self.water_pump_switch == other.water_pump_switch
+            and self.power_switch == other.power_switch
+            and self.oscillating_switch == other.oscillating_switch
+            and self.child_lock_switch == other.child_lock_switch
+            and self.fan_speed == other.fan_speed
+            and self.mode == other.mode
+            and self.target_humidity == other.target_humidity
+        )
+
     def to_bytes(self) -> bytes:
         """Get binary representation of this command"""
         command_flag = DeyeDeviceCommandFlag(0)

--- a/src/libdeye/device_state.py
+++ b/src/libdeye/device_state.py
@@ -112,6 +112,30 @@ class DeyeDeviceState:
             self.target_humidity,
         )
 
+    def __eq__(self, other: object) -> bool:
+        """Check if two device states are equal.
+
+        Only compares public attributes that represent the actual device state.
+        """
+        if not isinstance(other, DeyeDeviceState):
+            return False
+
+        return (
+            self.anion_switch == other.anion_switch
+            and self.water_pump_switch == other.water_pump_switch
+            and self.power_switch == other.power_switch
+            and self.oscillating_switch == other.oscillating_switch
+            and self.child_lock_switch == other.child_lock_switch
+            and self.defrosting == other.defrosting
+            and self.water_tank_full == other.water_tank_full
+            and self.fan_running == other.fan_running
+            and self.fan_speed == other.fan_speed
+            and self.mode == other.mode
+            and self.target_humidity == other.target_humidity
+            and self.environment_temperature == other.environment_temperature
+            and self.environment_humidity == other.environment_humidity
+        )
+
 
 class DeyeDeviceStateFlag(IntFlag):
     """Bit flags used in the state string"""

--- a/tests/test_device_command.py
+++ b/tests/test_device_command.py
@@ -147,3 +147,112 @@ def test_deye_device_command_to_json_all_off() -> None:
     }
 
     assert command.to_json() == expected_json
+
+
+def test_deye_device_command_equality() -> None:
+    """Test equality comparison between DeyeDeviceCommand instances"""
+    # Test equality with identical instances
+    command1 = DeyeDeviceCommand(
+        anion_switch=True,
+        water_pump_switch=True,
+        power_switch=True,
+        oscillating_switch=True,
+        child_lock_switch=True,
+        fan_speed=DeyeFanSpeed.HIGH,
+        mode=DeyeDeviceMode.AUTO_MODE,
+        target_humidity=70,
+    )
+    command2 = DeyeDeviceCommand(
+        anion_switch=True,
+        water_pump_switch=True,
+        power_switch=True,
+        oscillating_switch=True,
+        child_lock_switch=True,
+        fan_speed=DeyeFanSpeed.HIGH,
+        mode=DeyeDeviceMode.AUTO_MODE,
+        target_humidity=70,
+    )
+    assert command1 == command2
+    assert not (command1 != command2)
+
+    # Test inequality with different switch state
+    command3 = DeyeDeviceCommand(
+        anion_switch=False,  # Different from command1
+        water_pump_switch=True,
+        power_switch=True,
+        oscillating_switch=True,
+        child_lock_switch=True,
+        fan_speed=DeyeFanSpeed.HIGH,
+        mode=DeyeDeviceMode.AUTO_MODE,
+        target_humidity=70,
+    )
+    assert command1 != command3
+    assert not (command1 == command3)
+
+    # Test inequality with different fan speed
+    command4 = DeyeDeviceCommand(
+        anion_switch=True,
+        water_pump_switch=True,
+        power_switch=True,
+        oscillating_switch=True,
+        child_lock_switch=True,
+        fan_speed=DeyeFanSpeed.MIDDLE,  # Different from command1
+        mode=DeyeDeviceMode.AUTO_MODE,
+        target_humidity=70,
+    )
+    assert command1 != command4
+    assert not (command1 == command4)
+
+    # Test inequality with different mode
+    command5 = DeyeDeviceCommand(
+        anion_switch=True,
+        water_pump_switch=True,
+        power_switch=True,
+        oscillating_switch=True,
+        child_lock_switch=True,
+        fan_speed=DeyeFanSpeed.HIGH,
+        mode=DeyeDeviceMode.MANUAL_MODE,  # Different from command1
+        target_humidity=70,
+    )
+    assert command1 != command5
+    assert not (command1 == command5)
+
+    # Test inequality with different target humidity
+    command6 = DeyeDeviceCommand(
+        anion_switch=True,
+        water_pump_switch=True,
+        power_switch=True,
+        oscillating_switch=True,
+        child_lock_switch=True,
+        fan_speed=DeyeFanSpeed.HIGH,
+        mode=DeyeDeviceMode.AUTO_MODE,
+        target_humidity=50,  # Different from command1
+    )
+    assert command1 != command6
+    assert not (command1 == command6)
+
+    # Test equality comparison with a different type
+    assert command1 != "not a command"
+
+
+def test_deye_device_command_default_equality() -> None:
+    """Test equality with default instances"""
+    # Test equality with default instances
+    command1 = DeyeDeviceCommand()
+    command2 = DeyeDeviceCommand()
+    assert command1 == command2
+    assert not (command1 != command2)
+
+    # Create a command with explicit defaults that should equal a default command
+    command3 = DeyeDeviceCommand(
+        anion_switch=False,
+        water_pump_switch=False,
+        power_switch=False,
+        oscillating_switch=False,
+        child_lock_switch=False,
+        fan_speed=DeyeFanSpeed.LOW,
+        mode=DeyeDeviceMode.MANUAL_MODE,
+        target_humidity=60,
+    )
+    assert command1 == command3
+    assert not (command1 != command3)

--- a/tests/test_device_state.py
+++ b/tests/test_device_state.py
@@ -194,3 +194,110 @@ def test_deye_device_state_fog_missing_values() -> None:
     assert state.target_humidity == 60
     assert state.environment_temperature == 27
     assert state.environment_humidity == 27
+
+
+def test_deye_device_state_equality_same_state() -> None:
+    """Test that two device states with identical attributes are equal"""
+    state1 = DeyeDeviceState("14118100113B00000000000000000040300000000000")
+    state2 = DeyeDeviceState("14118100113B00000000000000000040300000000000")
+
+    assert state1 == state2
+    assert state2 == state1
+
+    # Identity equality
+    assert state1 == state1
+
+
+def test_deye_device_state_equality_different_state() -> None:
+    """Test that two device states with different attributes are not equal"""
+    state1 = DeyeDeviceState("14118100113B00000000000000000040300000000000")
+    state2 = DeyeDeviceState("14110703113B00000000000000000040300000000000")
+
+    assert state1 != state2
+    assert state2 != state1
+
+
+def test_deye_device_state_equality_modified_state() -> None:
+    """Test equality after modifying device state attributes"""
+    state1 = DeyeDeviceState("14118100113B00000000000000000040300000000000")
+    state2 = DeyeDeviceState("14118100113B00000000000000000040300000000000")
+
+    # Initially equal
+    assert state1 == state2
+
+    # Modify one attribute
+    state2.anion_switch = not state2.anion_switch
+    assert state1 != state2
+
+    # Make them equal again
+    state1.anion_switch = state2.anion_switch
+    assert state1 == state2
+
+    # Test with several attributes modified
+    state2.water_pump_switch = True
+    state2.target_humidity = 45
+    state2.fan_speed = DeyeFanSpeed.HIGH
+    assert state1 != state2
+
+
+def test_deye_device_state_equality_different_types() -> None:
+    """Test equality between a device state and other types of objects"""
+    state = DeyeDeviceState("14118100113B00000000000000000040300000000000")
+
+    # Compare with None
+    assert state is not None
+
+    # Compare with other types
+    assert state != "a string"
+    assert state != 123
+    assert state != {}
+    assert state != []
+
+
+def test_deye_device_state_equality_fog_and_classic() -> None:
+    """Test equality between states created from fog platform and classic"""
+    # Create state from classic protocol
+    state_classic = DeyeDeviceState("14118100113B00000000000000000040300000000000")
+
+    # Create a minimal fog state
+    fog_state: FogDevicePropertiesForTest = {
+        "NegativeIon": 0,
+        "WaterPump": 0,
+        "Power": 0,  # Different from classic
+        "SwingingWind": 0,
+        "KeyLock": 0,
+        "Demisting": 0,
+        "WaterTank": 0,
+        "Fan": 0,  # Different from classic
+        "WindSpeed": 2,  # Different from classic
+        "Mode": 2,  # Different from classic
+        "SetHumidity": 50,  # Different from classic
+        "CurrentAmbientTemperature": 25,  # Different from classic
+        "CurrentEnvironmentalHumidity": 40,  # Different from classic
+    }
+
+    state_fog = DeyeDeviceState(
+        cast(DeyeApiResponseFogPlatformDeviceProperties, fog_state)
+    )
+
+    # Verify they are initially different
+    assert state_fog != state_classic
+
+    # Make the fog state equal to the classic state by copying all attributes
+    state_fog.anion_switch = state_classic.anion_switch
+    state_fog.water_pump_switch = state_classic.water_pump_switch
+    state_fog.power_switch = state_classic.power_switch
+    state_fog.oscillating_switch = state_classic.oscillating_switch
+    state_fog.child_lock_switch = state_classic.child_lock_switch
+    state_fog.defrosting = state_classic.defrosting
+    state_fog.water_tank_full = state_classic.water_tank_full
+    state_fog.fan_running = state_classic.fan_running
+    state_fog.fan_speed = state_classic.fan_speed
+    state_fog.mode = state_classic.mode
+    state_fog.target_humidity = state_classic.target_humidity
+    state_fog.environment_temperature = state_classic.environment_temperature
+    state_fog.environment_humidity = state_classic.environment_humidity
+
+    # Now they should be equal
+    assert state_fog == state_classic
+    assert state_classic == state_fog


### PR DESCRIPTION
This commit adds __eq__ methods to DeyeDeviceCommand and DeyeDeviceState classes to enable direct comparison of their attributes. The implementation includes comprehensive test cases to verify:
- Equality between identical instances
- Inequality when attributes differ
- Handling of comparisons with different types
- Equality for default and modified instances
