### PR TITLE
fix: update paho-mqtt dependency version range

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ python_requires = >=3.10
 install_requires =
     aiohttp>=3.8,<4.0
     PyJWT>=2.0,<3.0
-    paho-mqtt>=1.6,<2
+    paho-mqtt>=1.6,<3
 
 [options.package_data]
 libdeye = py.typed

--- a/src/libdeye/mqtt_client.py
+++ b/src/libdeye/mqtt_client.py
@@ -10,10 +10,7 @@ from typing import Any, cast
 
 import paho.mqtt.client as mqtt
 
-from .cloud_api import (
-    DeyeApiResponseFogPlatformDeviceProperties,
-    DeyeCloudApi,
-)
+from .cloud_api import DeyeApiResponseFogPlatformDeviceProperties, DeyeCloudApi
 from .const import QUERY_DEVICE_STATE_COMMAND_CLASSIC
 from .device_command import DeyeDeviceCommand
 from .device_state import DeyeDeviceState
@@ -40,7 +37,7 @@ class BaseDeyeMqttClient(ABC):
         self._mqtt.on_connect = self._mqtt_on_connect
         self._mqtt.on_message = self._mqtt_on_message
         self._mqtt.on_disconnect = self._mqtt_on_disconnect
-        self._subscribers: dict[str, set[Callable[[mqtt.MQTTMessage], None]]] = {}
+        self._subscribers: dict[str, set[Callable[[Any], None]]] = {}
         self._pending_commands: list[tuple[str, bytes]] = []
 
     @abstractmethod
@@ -64,8 +61,8 @@ class BaseDeyeMqttClient(ABC):
         _mqtt: mqtt.Client,
         _userdata: None,
         _flags: dict[str, int],
-        _result_code: int,
-        _properties: mqtt.Properties | None = None,
+        _result_code: Any,
+        _properties: Any,
     ) -> None:
         for topic, callbacks in self._subscribers.items():
             if len(callbacks) > 0:
@@ -110,7 +107,7 @@ class BaseDeyeMqttClient(ABC):
     def _subscribe_topic(
         self,
         topic: str,
-        callback: Callable[[mqtt.MQTTMessage], None],
+        callback: Callable[[Any], None],
     ) -> Callable[[], None]:
         if topic not in self._subscribers:
             self._subscribers[topic] = set()

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -134,7 +134,7 @@ class TestBaseDeyeMqttClient:
         # Call _mqtt_on_connect
         with patch.object(base_client._mqtt, "subscribe") as mock_subscribe:
             with patch.object(base_client._mqtt, "publish") as mock_publish:
-                base_client._mqtt_on_connect(base_client._mqtt, None, {}, 0)
+                base_client._mqtt_on_connect(base_client._mqtt, None, {}, 0, {})
                 mock_subscribe.assert_called_once_with(topic1)
                 mock_publish.assert_called_once_with(pending_topic, pending_command)
                 assert len(base_client._pending_commands) == 0
@@ -278,7 +278,7 @@ class TestDeyeClassicMqttClient:
         assert classic_client._mqtt_host == "test.mqtt.host"
         assert classic_client._mqtt_ssl_port == 8883
         assert classic_client._endpoint == "test_endpoint"
-        classic_client._mqtt.username_pw_set.assert_called_once_with(
+        cast(MagicMock, classic_client._mqtt).username_pw_set.assert_called_once_with(
             "test_user", "test_password"
         )
 
@@ -458,7 +458,7 @@ class TestDeyeFogMqttClient:
         assert fog_client._mqtt_host == "test.mqtt.host"
         assert fog_client._mqtt_ssl_port == 8883
         assert fog_client._topic == "fogcloud/app/test_user/sub"
-        fog_client._mqtt.username_pw_set.assert_called_once_with(
+        cast(MagicMock, fog_client._mqtt).username_pw_set.assert_called_once_with(
             "test_user", "test_password"
         )
 


### PR DESCRIPTION
Expand paho-mqtt version constraint to allow minor version updates up to version 3.

This should make libdeye compatible with homeassistant 2025.3.
