### PR TITLE
feat: mark DYD-V58A3 as requiring power in fog partial updates

### DIFF
--- a/src/libdeye/const.py
+++ b/src/libdeye/const.py
@@ -214,6 +214,7 @@ PRODUCT_FEATURE_CONFIG: dict[str, DeyeProductPartialConfig] = {
     "2b770cba268611e89d4c00163e0c1b21": {  # V58A3
         "oscillating": False,
         "water_pump": False,
+        "requires_power_in_fog_partial_updates": True,
     },
     "17ab051af38611e89d4c00163e0c1b21": {  # W20A3
         "mode": [


### PR DESCRIPTION
The **DYD-V58A3** (Fog platform) can turn the device off when a partial Fog update omits the `Power` property while it is on — the same behavior as the **DYD-U20A3**.

This flags the V58A3 with `requires_power_in_fog_partial_updates: True` so `publish_command` re-asserts `Power=1` on partial updates.

Companion (HA integration): https://github.com/stackia/ha-deye-dehumidifier/pull/103