### PR TITLE
ci(actions): upgrade deprecated GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,10 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,12 +27,12 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Upgrade the GitHub Actions used by CI and PyPI publishing:

- `actions/checkout@v4` → `actions/checkout@v7`
- `actions/setup-python@v5` → `actions/setup-python@v7`
- replace deprecated `codecov/test-results-action@v1` with `codecov/codecov-action@v7` and `report_type: test_results`
- upgrade the coverage upload from `codecov/codecov-action@v5` to `@v7`

The updated actions and their relevant transitive `actions/github-script@v8` dependency use Node.js 24. This removes the Node.js 20 deprecation annotations seen during the libdeye 2.1.6 release and the first validation run of this PR. The Python version, build commands, coverage behavior, and PyPI publishing configuration remain unchanged.

## Validation

- Confirmed checkout v7, setup-python v7, and github-script v8 declare Node.js 24 runtimes
- Confirmed Codecov v7 supports `report_type: test_results`
- `.venv/bin/pre-commit run --files .github/workflows/test.yml .github/workflows/publish.yml`
- `git diff --check`
- PR CI exercises the updated actions directly