### PR TITLE
feat: support the DYD-P40

### DIFF
--- a/src/libdeye/const.py
+++ b/src/libdeye/const.py
@@ -29,6 +29,7 @@ class DeyeFanSpeed(IntEnum):
     MIDDLE = 2
     HIGH = 3
     FULL = 4
+    UNKNOWN_SPEED = 5
 
 
 class DeyeProductConfig(TypedDict):
@@ -64,6 +65,26 @@ class DeyeProductPartialConfig(TypedDict, total=False):
 
 
 PRODUCT_FEATURE_CONFIG: dict[str, DeyeProductPartialConfig] = {
+    "d71936c6951c11f0a8200242ac480009": {  # DYD-P40
+        "mode": [
+            DeyeDeviceMode.CLOTHES_DRYER_MODE,
+            DeyeDeviceMode.AIR_PURIFIER_MODE,
+            DeyeDeviceMode.AUTO_MODE,
+            DeyeDeviceMode.UNKNOWN_MODE,
+            DeyeDeviceMode.SLEEP_MODE,
+        ],
+        "fan_speed": [
+            DeyeFanSpeed.LOW,
+            DeyeFanSpeed.MIDDLE,
+            DeyeFanSpeed.HIGH,
+            DeyeFanSpeed.UNKNOWN_SPEED,
+        ],
+        "min_target_humidity": 40,
+        "max_target_humidity": 70,
+        "anion": True,
+        "oscillating": True,
+        "water_pump": False,
+    },
     "07dddba41c3011e8829100163e0f811e": {  # 612S
         "mode": [],
         "fan_speed": [DeyeFanSpeed.LOW, DeyeFanSpeed.HIGH],


### PR DESCRIPTION
### What breaks today

A **DYD-P40** (product id `d71936c6951c11f0a8200242ac480009`) reports `WindSpeed = 5`, which `DeyeFanSpeed` doesn't define, so every poll raises:

```
File ".../libdeye/device_state.py", line 92, in _parse_state_fog
    self.fan_speed = DeyeFanSpeed(state.get("WindSpeed", DeyeFanSpeed.STOPPED))
ValueError: 5 is not a valid DeyeFanSpeed
```

The enum member alone isn't enough. Consumers map state through `ordered_list_item_to_percentage(feature_config["fan_speed"], …)`, which raises for a speed absent from the product's list — and this product has no `PRODUCT_FEATURE_CONFIG` entry, so it inherits the default listing speeds 1–4.

### Everything here was measured, not guessed

The product catalogue carries no capability metadata (the P40 entry has only name/brand/picture/config_guide), so I set each property on the real appliance and read it back, capturing a baseline first and restoring it afterwards (zero drift):

| Property | Accepted | Rejected |
|---|---|---|
| `Mode` | 1, 2, 3, 4, 6 | **0 (MANUAL)**, 5 |
| `WindSpeed` | 1, 2, 3, **5** | **4 (FULL)** |
| `SetHumidity` | 40–70 | 20, 25, 30, 35, 75, 80, 85, 90 |
| `NegativeIon` | 1 → sticks | — |
| `SwingingWind` | 1 → sticks | — |
| `WaterPump` | — | 1 → reads back 0 |

Since **4 is rejected while 5 is accepted**, 5 is not a step above `FULL` — most likely an auto/smart speed. I named it `UNKNOWN_SPEED`, following the existing convention for unidentified values (`DeyeDeviceMode` already carries `UNKNOWN_MODE` and `UNKNOWN_MODE_2`). Happy to rename if you know what it is.

### Two further observations, not addressed here

Recording them since they affect how this model maps, but neither is expressible in a product config:

1. **`Fan` is read-only on this model and stays `1` even with `Power = 0`** (`CompressorStatus` goes to 0 instead). `_parse_state_fog` maps it to `fan_running`, so that flag is effectively stuck true — which makes the derived "is it running" state wrong.
2. **`UV` is settable** on this unit but has no model here.

Separate PR against `ha-deye-dehumidifier` (#108) fixes an independent issue that had to be cleared before any of this was reachable: the Fog client isn't connected for devices whose platform isn't exactly `Fog`, and the P40 reports `platform = 3`.